### PR TITLE
Fixes #5, now it list all tags on -a switch

### DIFF
--- a/drib.sh
+++ b/drib.sh
@@ -183,14 +183,16 @@ This directory contains additional information about the published artifacts of 
 
 -   [the \`remote\` directory](remote/):
 
-   -   Gathered from the Docker Hub/Registry API
-   -   Manifest data, platform, layers, exposed ports, dockerfile recipe...
-   -   environment variables, dates, etc.
+    -   Gathered from the Docker Hub/Registry API
+    -   Manifest data, platform, layers, exposed ports, dockerfile recipe...
+    -   environment variables, dates, etc.
 
 -   [the \`local\` directory](local/):
 
-   -   Inspected from the image on-disk after it is pulled
-   -   Image ID, creation date, virtual size, architecture, environment and entry point
+    -   Inspected from the image on-disk after it is pulled
+    -   Image ID, creation date, virtual size, architecture, environment and entry point
+
+Also, the file [tag_list.md](tag_list.md) has the list of all tags covered on this directory with links to it's details.
 
 EOF
 }
@@ -522,7 +524,7 @@ get_all_tags() {
 # create file tags.md listing all tags found.
 create_tags_md() {
 	local tags="$1"
-	local file="tags_listing.md"
+	local file="tag_list.md"
 
 	echo "
 # Tag listing for the repository $image_md


### PR DESCRIPTION
Solution was to switch to docker api v1 to get the full list of tags, simple is beautiful